### PR TITLE
chore: use fork repository links

### DIFF
--- a/module.json
+++ b/module.json
@@ -33,7 +33,7 @@
         "path": "languages/it.json"
     }
   ],
-  "url": "https://github.com/MrVauxs/dnd5e-animations",
+  "url": "https://github.com/shuanz/dnd5e-animations",
   "compatibility": {
     "minimum": "12",
     "verified": "13"
@@ -88,7 +88,7 @@
       }
     ]
   },
-  "changelog": "https://github.com/MrVauxs/dnd5e-animations/blob/master/CHANGELOG.md",
-  "manifest": "https://github.com/MrVauxs/dnd5e-animations/releases/latest/download/module.json",
-  "download": "https://github.com/MrVauxs/dnd5e-animations/releases/latest/download/module.zip"
+  "changelog": "https://github.com/shuanz/dnd5e-animations/blob/master/CHANGELOG.md",
+  "manifest": "https://raw.githubusercontent.com/shuanz/dnd5e-animations/master/module.json",
+  "download": "https://github.com/shuanz/dnd5e-animations/releases/latest/download/module.zip"
 }


### PR DESCRIPTION
## Summary
- point module URLs to shuanz/dnd5e-animations repo so Foundry can fetch this fork

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689287239a348322adf4a82aaa349927